### PR TITLE
corrected remarks

### DIFF
--- a/include/list.h
+++ b/include/list.h
@@ -8,7 +8,7 @@
 #include <time.h>
 
 enum { rand_range = 100 };
-enum { array_size = 23 };
+enum { array_size = 33 };
 
 typedef struct Node {
     int          value;
@@ -20,14 +20,13 @@ typedef struct List {
     size_t          size;
     Node           *head;
     Node           *tail;
-    pthread_mutex_t mutex;
 } List;
 
 List *create_list();
-void  delete_list(List **list);
+void  delete_list(List *list);
 void  push_back(List *list, int value);
-void  pop_front(List *list);
-void  pop_back(List *list);
+int  pop_front(List *list);
+int  pop_back(List *list);
 void  print_list(const List *list);
 void  random_fill(int *arr, size_t size);
 List *init_and_fill_list();

--- a/include/threads.h
+++ b/include/threads.h
@@ -4,8 +4,9 @@
 
 #include <pthread.h>
 #include <unistd.h>
-
+#include <stdarg.h>
 #include "list.h"
+extern pthread_mutex_t print_mutex;
 
 enum { sleep_time = 1 };
 
@@ -16,5 +17,6 @@ typedef struct {
 
 void *process_bit_count(void *arg);
 void  element_processing();
+void safe_print(const char *format, ...);
 int   count_ones_or_zeroes(int num, int thread_index);
 #endif //THREADS_H

--- a/src/list.c
+++ b/src/list.c
@@ -5,36 +5,33 @@
 List* create_list() {
     List *list = (List*) malloc(sizeof(List));
     if (list == NULL) {
-        fprintf(stderr, "Memory allocation failed\n");
+        perror("Memory allocation failed");
         return NULL;
     }
     list->size = 0;
     list->head = list->tail = NULL;
-    pthread_mutex_init(&list->mutex, NULL);
     return list;
 }
 
-void delete_list(List **list) {
-    if (list == NULL || *list == NULL) return;
-    Node *current = (*list)->head;
+void delete_list(List *list) {
+    if (list == NULL) return;
+    Node *current = list->head;
     Node *next = NULL;
     while (current) {
         next = current->next;
         free(current);
         current = next;
     }
-    pthread_mutex_destroy(&(*list)->mutex);
-    free(*list);
-    (*list) = NULL;
+    free(list);
 }
 
-void pop_front (List *list) {
+int pop_front (List *list) {
     if (list == NULL || list->head == NULL) {
-        fprintf(stderr, "List is empty or NULL\n");
-        return;
+        return -1;
     }
 
     Node *prev = list->head;
+    int value = prev->value;
     list->head = prev->next;
     if (list->head) {
         list->head->prev = NULL;
@@ -43,17 +40,17 @@ void pop_front (List *list) {
         list->tail = NULL;
     }
     free(prev);
- 
-    list->size--; 
-    pthread_mutex_unlock(&list->mutex);
+    list->size--;
+    return value;
 }
 
-void pop_back (List *list) {
+int pop_back (List *list) {
     if (list == NULL || list->tail == NULL) {
-        fprintf(stderr, "List is empty or NULL\n");
-        return;
+        return -1;
     }
+
     Node *next =  list->tail;
+    int value = next->value;
     list->tail = next->prev;
     if (list->tail) {
         list->tail->next = NULL;
@@ -62,9 +59,8 @@ void pop_back (List *list) {
         list->head = NULL;
     }
     free(next);
-
     list->size--; 
-    pthread_mutex_unlock(&list->mutex);
+    return value;
 }
 
 void push_back (List *list, int value)
@@ -79,16 +75,14 @@ void push_back (List *list, int value)
     tmp->next = NULL;
     tmp->prev = list->tail;
 
-    pthread_mutex_lock(&list->mutex);
     if (list->tail) {
         list->tail->next = tmp;
     }
-    list->tail = tmp;
-    if(list->head == NULL) {
+    else {
         list->head = tmp;
     }
+    list->tail = tmp;
     list->size++;
-    pthread_mutex_unlock(&list->mutex);
 }
 
 void print_list(const List *list)
@@ -96,13 +90,11 @@ void print_list(const List *list)
     if (list == NULL) return;
     Node *p;
     p = list->head;
-    pthread_mutex_lock((pthread_mutex_t *)&list->mutex);
     while(p) {
         printf("%d ", p->value);
         p = p->next;
     }  
     printf("\n");
-    pthread_mutex_unlock((pthread_mutex_t *)&list->mutex);
 }
 
 void random_fill(int *arr, size_t size) {
@@ -114,7 +106,7 @@ void random_fill(int *arr, size_t size) {
 List* init_and_fill_list() {
 int *arr = malloc(array_size * sizeof(int));
     if (arr == NULL) {
-        printf("Memory allocation failed\n");
+        perror("Memory allocation failed");
         return NULL;
     }
 
@@ -123,7 +115,7 @@ int *arr = malloc(array_size * sizeof(int));
     
     List *list = create_list();
     if (list == NULL) {
-        fprintf(stderr, "Failed to create list\n");
+        perror( "Failed to create list");
         return NULL;
     }
 
@@ -131,7 +123,5 @@ int *arr = malloc(array_size * sizeof(int));
         push_back(list, arr[i]);
         
     }
-    printf("List after adding elements: ");
-    print_list(list);
     return list;
 }


### PR DESCRIPTION
Separate Mutexes for Head and Tail: Allows pop_front and pop_back to operate in parallel by using independent mutexes.

Protected Access in pop_front and pop_back: Added mutexes within each function to safely handle the list’s head and tail, preventing race conditions.

Removed fprintf in Core Functions: Replaced direct error outputs with return codes to improve portability and flexibility.

Return Values in pop_front and pop_back: Modified functions to return values or error codes, making them more functional and reliable.

Fixed push_back()